### PR TITLE
Set up Saerok API client and WireMock smoke test

### DIFF
--- a/.codex/brief.md
+++ b/.codex/brief.md
@@ -1,0 +1,4 @@
+# brief
+- Read BE contracts from /workspace/saerok-BE and context/saerok-BE/endpoints.txt.
+- Never start BE here. Use WireMock stubs in tests; no outbound network.
+- Use a single RestClient bean configured by `saerok.api.base-url`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+- Editable code: /workspace/saerok-admin
+- Read-only context: /workspace/saerok-BE (cloned by setup), context/saerok-BE/endpoints.txt
+- Do NOT run saerok-BE in this container. (BE runs locally via ./up.sh ./down.sh)
+
+- API contract source:
+  - Controllers/DTOs under /workspace/saerok-BE/src/main/**
+  - Quick index: context/saerok-BE/endpoints.txt
+  - Global prefix in BE is configurable (api_prefix). Treat it as external config.
+
+- How to run admin here:
+  - Build: ./gradlew clean build --console=plain
+  - Run:   ./gradlew bootRun --console=plain --args='--server.port=8081'
+  - Inject BE base URL via: --saerok.api.base-url=... or env SAEROK_API_BASE_URL

--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,10 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testImplementation 'org.springframework.security:spring-security-test'
+        testImplementation 'org.wiremock:wiremock-standalone:3.6.0'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/apu/saerok_admin/infra/SaerokApiClientConfig.java
+++ b/src/main/java/apu/saerok_admin/infra/SaerokApiClientConfig.java
@@ -1,0 +1,18 @@
+package apu.saerok_admin.infra;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.*;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(SaerokApiProps.class)
+public class SaerokApiClientConfig {
+  @Bean
+  RestClient saerokRestClient(SaerokApiProps props) {
+    return RestClient.builder().baseUrl(props.baseUrl()).build();
+  }
+}
+
+@ConfigurationProperties(prefix = "saerok.api")
+record SaerokApiProps(String baseUrl) {}

--- a/src/main/resources/application-codex.yml
+++ b/src/main/resources/application-codex.yml
@@ -1,0 +1,3 @@
+saerok:
+  api:
+    base-url: http://localhost:8080

--- a/src/test/java/apu/saerok_admin/contract/SaerokAdminContractSmokeTest.java
+++ b/src/test/java/apu/saerok_admin/contract/SaerokAdminContractSmokeTest.java
@@ -1,0 +1,73 @@
+package apu.saerok_admin.contract;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.RestClient;
+import apu.saerok_admin.infra.SaerokApiClientConfig;
+
+@SpringBootTest(
+  classes = {SaerokApiClientConfig.class},
+  properties = "spring.main.web-application-type=none"
+)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SaerokAdminContractSmokeTest {
+
+  static WireMockServer wm;
+
+  @Autowired
+  RestClient restClient;
+
+  @BeforeAll
+  void start() {
+    if (wm == null) {
+      wm = new WireMockServer(0);
+    }
+    if (!wm.isRunning()) {
+      wm.start();
+    }
+    configureFor("localhost", wm.port());
+  }
+
+  @AfterAll
+  void stop() {
+    if (wm != null) wm.stop();
+  }
+
+  @DynamicPropertySource
+  static void props(DynamicPropertyRegistry r) {
+    r.add("saerok.api.base-url", () -> {
+      if (wm == null) {
+        wm = new WireMockServer(0);
+      }
+      if (!wm.isRunning()) {
+        wm.start();
+        configureFor("localhost", wm.port());
+      }
+      return "http://localhost:" + wm.port();
+    });
+  }
+
+  @Test
+  void refreshToken_contract_smoke() {
+    stubFor(post(urlEqualTo("/api/v1/auth/refresh"))
+      .willReturn(aResponse()
+        .withStatus(200)
+        .withHeader("Content-Type","application/json")
+        .withBody("{\"accessToken\":\"dummy\",\"signupStatus\":\"COMPLETED\"}")));
+
+    var res = restClient.post()
+      .uri("/api/v1/auth/refresh")
+      .retrieve()
+      .toEntity(String.class);
+
+    assertThat(res.getStatusCode().is2xxSuccessful()).isTrue();
+    assertThat(res.getBody()).contains("accessToken");
+  }
+}


### PR DESCRIPTION
## Summary
- add repository guidance files for agents and codex usage
- configure a reusable RestClient bound to saerok.api.base-url with default codex profile
- introduce WireMock-based contract smoke test and dependency

## Testing
- ./gradlew clean test --console=plain
- ./gradlew bootRun --console=plain --args='--server.port=8081' &
- curl -s -i http://localhost:8081/


------
https://chatgpt.com/codex/tasks/task_e_68d0d97f77d8832cbca7821c77417f3f