### PR TITLE
Add coding conventions for saerok-admin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,17 @@
   - Build: ./gradlew clean build --console=plain
   - Run:   ./gradlew bootRun --console=plain --args='--server.port=8081'
   - Inject BE base URL via: --saerok.api.base-url=... or env SAEROK_API_BASE_URL
+
+## Coding conventions
+
+To keep the admin service consistent with the existing style in `saerok-BE`, follow these conventions for all Java and Kotlin source under this repository:
+
+- **Indentation:** Use 4 spaces per indentation level. Do not use tab characters. Method bodies, control-flow blocks, and class members should be indented once under their declarations, mirroring the backend project.
+- **Braces:** Place opening braces on the same line as the declaration (classes, methods, `if`/`else`, `try`/`catch`, etc.) and closing braces on their own line aligned with the start of the declaration.
+- **Spacing:** Keep a single space between keywords and parentheses (e.g., `if (`), around binary operators, and after commas. Avoid trailing whitespace at the end of lines.
+- **Imports:** Group imports by package (standard library, third-party, project) and keep each group sorted alphabetically without unused imports. Leave a single blank line between groups, matching the structure in `saerok-BE`.
+- **Blank lines:** Use blank lines to separate logical sections—between package and import statements, between import groups, and between class members when it improves readability. Avoid multiple consecutive blank lines.
+- **Naming:** Follow Java naming conventions as seen in `saerok-BE`: `PascalCase` for classes, `camelCase` for methods and variables, `UPPER_SNAKE_CASE` for constants.
+- **Annotations:** Place annotations directly above the element they decorate without blank lines, preserving the order used in the backend (Spring stereotypes closest to the declaration, followed by additional annotations).
+
+These rules should be treated as mandatory for any code you add or modify so that both repositories share the same formatting baseline.


### PR DESCRIPTION
## Summary
- add a coding convention section to AGENTS.md so admin work mirrors saerok-BE formatting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0de03f27c832cbfe03bcbdff9eb00