### PR TITLE
Add Docker configuration for saerok-admin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# ===== Build stage =====
+FROM gradle:8.8-jdk21 AS builder
+WORKDIR /app
+
+COPY build.gradle settings.gradle gradlew ./
+COPY gradle gradle
+RUN chmod +x gradlew
+RUN ./gradlew --no-daemon dependencies || true
+
+COPY . .
+RUN chmod +x gradlew
+RUN ./gradlew --no-daemon clean bootJar
+
+# ===== Runtime stage =====
+FROM eclipse-temurin:21-jre
+ENV TZ=Asia/Seoul
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8081
+
+ENTRYPOINT ["sh","-c","java $JAVA_OPTS -jar /app/app.jar --server.port=${SERVER_PORT:-8081} --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-local}"]

--- a/deploy/docker-compose.override.yml
+++ b/deploy/docker-compose.override.yml
@@ -1,0 +1,32 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: saerok-admin-local:latest
+    container_name: saerok-admin-app
+    restart: unless-stopped
+
+    env_file:
+      - ../.env
+
+    environment:
+      SPRING_PROFILES_ACTIVE: "${SPRING_PROFILES_ACTIVE:-local}"
+      SERVER_PORT: "${SERVER_PORT:-8081}"
+      SAEROK_API_BASE_URL: "${SAEROK_API_BASE_URL:-http://host.docker.internal:8080}"
+      JAVA_OPTS: >-
+        -Duser.timezone=Asia/Seoul
+        -XX:MaxRAMPercentage=60
+
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+    ports:
+      - "${SERVER_PORT:-8081}:${SERVER_PORT:-8081}"
+
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:${SERVER_PORT:-8081} >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,2 @@
+services:
+  app: {}

--- a/down.sh
+++ b/down.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# 기본 compose + override 오버레이로 내리기 (로컬 개발용)
+docker compose \
+  -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.override.yml \
+  down

--- a/up.sh
+++ b/up.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# 기본 compose + override 오버레이로 띄우기 (로컬 개발용)
+docker compose \
+  -f deploy/docker-compose.yml \
+  -f deploy/docker-compose.override.yml \
+  up -d


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile to build and run the admin service container
- introduce docker-compose overlays and helper scripts for local Docker workflows

## Testing
- ./gradlew clean build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d0dee9ed2c832c9d6c9e22ac25b6fe