### PR TITLE
Fix Thymeleaf layout recursion bug

### DIFF
--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head th:replace="fragments/_head :: head(~{::title})">
-    <title>사록 어드민 로그인</title>
-</head>
+<head th:replace="~{fragments/_head :: head('사록 어드민 로그인')}"></head>
 <body class="d-flex align-items-center justify-content-center" style="min-height: 100vh; background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);">
 <div class="card shadow-lg border-0" style="min-width: 360px; max-width: 420px;">
     <div class="card-body p-4 p-md-5">

--- a/src/main/resources/templates/collections/detail.html
+++ b/src/main/resources/templates/collections/detail.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>새록 상세</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>새록 상세</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="row g-4">
             <div class="col-12 col-lg-8">
                 <div class="card card-shadow-sm border-0 mb-4">
@@ -114,6 +109,4 @@
             </div>
         </div>
     </th:block>
-</th:block>
-</body>
 </html>

--- a/src/main/resources/templates/collections/list.html
+++ b/src/main/resources/templates/collections/list.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>새록 관리</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>새록 관리</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="card card-shadow-sm border-0 mb-4">
             <div class="card-body">
                 <form class="row g-3 align-items-end" method="get">
@@ -159,9 +154,7 @@
                 </div>
             </div>
         </div>
-    </th:block>
-</th:block>
-<script>
+    <script>
     const checkboxes = document.querySelectorAll('.collection-checkbox');
     const selectAll = document.getElementById('selectAllCollections');
     const selectAllHead = document.getElementById('selectAllCollectionsHead');
@@ -211,6 +204,6 @@
             statusModal.querySelector('#statusTarget').textContent = target;
         });
     }
-</script>
-</body>
+    </script>
+</th:block>
 </html>

--- a/src/main/resources/templates/comments/list.html
+++ b/src/main/resources/templates/comments/list.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>댓글 관리</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>댓글 관리</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="card card-shadow-sm border-0 mb-4">
             <div class="card-body">
                 <form class="row g-3 align-items-end" method="get">
@@ -172,9 +167,7 @@
                 </div>
             </div>
         </div>
-    </th:block>
-</th:block>
-<script>
+    <script>
     const commentCheckboxes = document.querySelectorAll('.comment-checkbox');
     const selectAllComments = document.getElementById('selectAllComments');
     const selectAllCommentsHead = document.getElementById('selectAllCommentsHead');
@@ -229,6 +222,6 @@
     if (bulkHideModal) {
         bulkHideModal.addEventListener('show.bs.modal', updateCommentBulkCount);
     }
-</script>
-</body>
+    </script>
+</th:block>
 </html>

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title th:text="${pageTitle} + ' | 사록 어드민'">대시보드</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title th:text="${pageTitle} + ' | 사록 어드민'">대시보드</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <section class="row g-4 mb-4">
             <div class="col-12 col-xl-3 col-md-6" th:each="metric : ${metrics}">
                 <div class="card card-shadow-sm h-100 border-0">
@@ -95,6 +90,4 @@
             </div>
         </section>
     </th:block>
-</th:block>
-</body>
 </html>

--- a/src/main/resources/templates/dex/detail.html
+++ b/src/main/resources/templates/dex/detail.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>도감 상세</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>도감 상세</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="row g-4">
             <div class="col-12 col-lg-8">
                 <div class="card card-shadow-sm border-0 mb-4">
@@ -89,6 +84,4 @@
             </div>
         </div>
     </th:block>
-</th:block>
-</body>
 </html>

--- a/src/main/resources/templates/dex/form.html
+++ b/src/main/resources/templates/dex/form.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>도감 작성</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>도감 작성</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <form class="row g-4" novalidate>
             <div class="col-12 col-xl-8">
                 <div class="card card-shadow-sm border-0 mb-4">
@@ -106,9 +101,7 @@
                 </div>
             </div>
         </form>
-    </th:block>
-</th:block>
-<script>
+    <script>
     function syncRarityButtons() {
         document.querySelectorAll('.btn-check').forEach(function (radio) {
             const label = document.querySelector('label[for="' + radio.id + '"]');
@@ -121,6 +114,6 @@
         input.addEventListener('change', syncRarityButtons);
     });
     syncRarityButtons();
-</script>
-</body>
+    </script>
+</th:block>
 </html>

--- a/src/main/resources/templates/dex/list.html
+++ b/src/main/resources/templates/dex/list.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>도감 관리</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>도감 관리</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="card card-shadow-sm border-0 mb-4">
             <div class="card-body">
                 <form class="row g-3 align-items-end" method="get">
@@ -131,9 +126,7 @@
                 </div>
             </div>
         </div>
-    </th:block>
-</th:block>
-<script>
+    <script>
     const deleteDexModal = document.getElementById('deleteDexModal');
     if (deleteDexModal) {
         deleteDexModal.addEventListener('show.bs.modal', function (event) {
@@ -145,6 +138,6 @@
             }
         });
     }
-</script>
-</body>
+    </script>
+</th:block>
 </html>

--- a/src/main/resources/templates/fragments/_head.html
+++ b/src/main/resources/templates/fragments/_head.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head th:fragment="head(title)">
+<head th:fragment="head(pageTitle)">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title th:replace="~{::title}">사록 어드민</title>
+    <title th:text="${pageTitle != null ? pageTitle + ' | 사록 어드민' : '사록 어드민'}">사록 어드민</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/src/main/resources/templates/layout/base.html
+++ b/src/main/resources/templates/layout/base.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<th:block th:fragment="layout(title, pageTitle, activeMenu, breadcrumbs, content)">
-    <head th:replace="fragments/_head :: head(~{::title})">
-        <title th:text="${pageTitle} + ' | 사록 어드민'">사록 어드민</title>
-    </head>
+<th:block th:fragment="layout(pageTitle, activeMenu, breadcrumbs, content)">
+    <head th:replace="~{fragments/_head :: head(${pageTitle})}"></head>
     <body>
     <div class="d-flex">
         <div th:replace="fragments/_sidebar :: sidebar(${activeMenu})"></div>
@@ -18,7 +16,7 @@
             </main>
         </div>
     </div>
-    <div th:replace="fragments/_toast :: toast(${toastMessages})"></div>
+    <div th:replace="~{fragments/_toast :: toast(${toastMessages})}"></div>
     </body>
 </th:block>
 </html>

--- a/src/main/resources/templates/notifications/compose.html
+++ b/src/main/resources/templates/notifications/compose.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>시스템 알림 발송</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>시스템 알림 발송</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="row g-4">
             <div class="col-12 col-xl-8">
                 <div class="card card-shadow-sm border-0">
@@ -128,9 +123,7 @@
                 </div>
             </div>
         </div>
-    </th:block>
-</th:block>
-<script>
+    <script>
     const scheduleToggle = document.getElementById('scheduleToggle');
     const scheduleDate = document.getElementById('scheduleDate');
     const scheduleTime = document.getElementById('scheduleTime');
@@ -141,6 +134,6 @@
             if (scheduleTime) scheduleTime.disabled = !enabled;
         });
     }
-</script>
-</body>
+    </script>
+</th:block>
 </html>

--- a/src/main/resources/templates/reports/detail.html
+++ b/src/main/resources/templates/reports/detail.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>신고 상세</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>신고 상세</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="row g-4">
             <div class="col-12 col-lg-8">
                 <div class="card card-shadow-sm border-0 mb-4">
@@ -143,6 +138,4 @@
             </div>
         </div>
     </th:block>
-</th:block>
-</body>
 </html>

--- a/src/main/resources/templates/reports/list.html
+++ b/src/main/resources/templates/reports/list.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>신고 관리</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>신고 관리</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="card card-shadow-sm border-0 mb-4">
             <div class="card-body">
                 <form class="row g-3 align-items-end" method="get">
@@ -138,9 +133,7 @@
                 </div>
             </div>
         </div>
-    </th:block>
-</th:block>
-<script>
+    <script>
     const processModal = document.getElementById('processReportModal');
     if (processModal) {
         processModal.addEventListener('show.bs.modal', event => {
@@ -157,6 +150,6 @@
             deleteModal.querySelector('#deleteReportId').textContent = target;
         });
     }
-</script>
-</body>
+    </script>
+</th:block>
 </html>

--- a/src/main/resources/templates/users/detail.html
+++ b/src/main/resources/templates/users/detail.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>사용자 상세</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>사용자 상세</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="row g-4">
             <div class="col-12 col-xl-4">
                 <div class="card card-shadow-sm border-0 mb-4">
@@ -132,6 +127,4 @@
             </div>
         </div>
     </th:block>
-</th:block>
-</body>
 </html>

--- a/src/main/resources/templates/users/list.html
+++ b/src/main/resources/templates/users/list.html
@@ -1,12 +1,7 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <title>사용자 관리</title>
-</head>
-<body>
-<th:block th:replace="layout/base :: layout(~{::title}, ${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})">
-    <title>사용자 관리</title>
-    <th:block th:fragment="content">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
+<th:block th:fragment="content">
         <div class="card card-shadow-sm border-0 mb-4">
             <div class="card-body">
                 <form class="row g-3 align-items-end" method="get">
@@ -139,25 +134,23 @@
                 </div>
             </div>
         </div>
-    </th:block>
+    <script>
+        const userStatusModal = document.getElementById('userStatusModal');
+        if (userStatusModal) {
+            userStatusModal.addEventListener('show.bs.modal', event => {
+                const button = event.relatedTarget;
+                const target = button ? button.getAttribute('data-user') : '사용자';
+                userStatusModal.querySelector('#userStatusTarget').textContent = target;
+            });
+        }
+        const userNotifyModal = document.getElementById('userNotifyModal');
+        if (userNotifyModal) {
+            userNotifyModal.addEventListener('show.bs.modal', event => {
+                const button = event.relatedTarget;
+                const target = button ? button.getAttribute('data-user') : '사용자';
+                userNotifyModal.querySelector('#userNotifyTarget').textContent = target;
+            });
+        }
+    </script>
 </th:block>
-<script>
-    const userStatusModal = document.getElementById('userStatusModal');
-    if (userStatusModal) {
-        userStatusModal.addEventListener('show.bs.modal', event => {
-            const button = event.relatedTarget;
-            const target = button ? button.getAttribute('data-user') : '사용자';
-            userStatusModal.querySelector('#userStatusTarget').textContent = target;
-        });
-    }
-    const userNotifyModal = document.getElementById('userNotifyModal');
-    if (userNotifyModal) {
-        userNotifyModal.addEventListener('show.bs.modal', event => {
-            const button = event.relatedTarget;
-            const target = button ? button.getAttribute('data-user') : '사용자';
-            userNotifyModal.querySelector('#userNotifyTarget').textContent = target;
-        });
-    }
-</script>
-</body>
 </html>


### PR DESCRIPTION
## Summary
- update the base layout fragment to pass page titles directly to the head fragment and switch to the new fragment expression syntax
- adjust the shared head fragment to render titles from string parameters and keep toast inclusion compatible
- rewrite admin templates to use the updated layout invocation and keep page scripts inside their content fragments to avoid recursive fragment resolution

## Testing
- ./gradlew clean build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d0ef38f138832cbe0ba147b051052a