### PR TITLE
Add deterministic service health client tests

### DIFF
--- a/src/main/java/apu/saerok_admin/infra/SaerokApiClientConfig.java
+++ b/src/main/java/apu/saerok_admin/infra/SaerokApiClientConfig.java
@@ -1,17 +1,24 @@
 package apu.saerok_admin.infra;
 
+import java.time.Clock;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
 @Configuration
 @EnableConfigurationProperties(SaerokApiProps.class)
 public class SaerokApiClientConfig {
-  @Bean
-  RestClient saerokRestClient(SaerokApiProps props) {
-    return RestClient.builder().baseUrl(props.baseUrl()).build();
-  }
+    @Bean
+    RestClient saerokRestClient(SaerokApiProps props) {
+        return RestClient.builder().baseUrl(props.baseUrl()).build();
+    }
+
+    @Bean
+    Clock systemClock() {
+        return Clock.systemDefaultZone();
+    }
 }
 
 @ConfigurationProperties(prefix = "saerok.api")

--- a/src/main/java/apu/saerok_admin/infra/ServiceHealthClient.java
+++ b/src/main/java/apu/saerok_admin/infra/ServiceHealthClient.java
@@ -1,0 +1,63 @@
+package apu.saerok_admin.infra;
+
+import apu.saerok_admin.web.view.ServiceHealthStatus;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+public class ServiceHealthClient {
+
+    private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
+            new ParameterizedTypeReference<>() {};
+
+    private final RestClient saerokRestClient;
+    private final Clock clock;
+
+    public ServiceHealthClient(RestClient saerokRestClient, Clock clock) {
+        this.saerokRestClient = saerokRestClient;
+        this.clock = clock;
+    }
+
+    public ServiceHealthStatus checkHealth() {
+        LocalDateTime checkedAt = LocalDateTime.now(clock);
+        try {
+            ResponseEntity<Map<String, Object>> response = saerokRestClient.get()
+                    .uri("/health")
+                    .retrieve()
+                    .toEntity(MAP_TYPE);
+
+            boolean alive = response.getStatusCode().is2xxSuccessful();
+            String message = alive
+                    ? extractStatusMessage(response.getBody())
+                    : "HTTP 상태 코드 " + response.getStatusCode().value();
+
+            return new ServiceHealthStatus(alive, message, checkedAt);
+        } catch (RestClientException exception) {
+            String message = exception.getMessage();
+            if (message == null || message.isBlank()) {
+                message = "요청 중 오류가 발생했습니다.";
+            }
+            return new ServiceHealthStatus(false, message, checkedAt);
+        }
+    }
+
+    private String extractStatusMessage(Map<String, Object> body) {
+        if (body == null || body.isEmpty()) {
+            return "서버가 정상 응답했습니다.";
+        }
+
+        Object status = body.get("status");
+        if (status != null) {
+            return "상태: " + Objects.toString(status);
+        }
+
+        return "서버가 정상 응답했습니다.";
+    }
+}

--- a/src/main/java/apu/saerok_admin/web/DashboardController.java
+++ b/src/main/java/apu/saerok_admin/web/DashboardController.java
@@ -1,5 +1,6 @@
 package apu.saerok_admin.web;
 
+import apu.saerok_admin.infra.ServiceHealthClient;
 import apu.saerok_admin.web.view.Breadcrumb;
 import apu.saerok_admin.web.view.DashboardMetric;
 import apu.saerok_admin.web.view.RecentDexEntry;
@@ -14,12 +15,19 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class DashboardController {
 
+    private final ServiceHealthClient serviceHealthClient;
+
+    public DashboardController(ServiceHealthClient serviceHealthClient) {
+        this.serviceHealthClient = serviceHealthClient;
+    }
+
     @GetMapping("/")
     public String dashboard(Model model) {
         model.addAttribute("pageTitle", "대시보드");
         model.addAttribute("activeMenu", "dashboard");
         model.addAttribute("breadcrumbs", List.of(Breadcrumb.active("대시보드")));
         model.addAttribute("toastMessages", List.of());
+        model.addAttribute("serviceHealth", serviceHealthClient.checkHealth());
         model.addAttribute("metrics", List.of(
                 new DashboardMetric("오늘 신고", "18건", "bi-flag", "danger", "지난주 대비 +12%"),
                 new DashboardMetric("미처리 신고", "7건", "bi-exclamation-triangle", "warning", "48시간 초과 2건"),

--- a/src/main/java/apu/saerok_admin/web/view/ServiceHealthStatus.java
+++ b/src/main/java/apu/saerok_admin/web/view/ServiceHealthStatus.java
@@ -1,0 +1,6 @@
+package apu.saerok_admin.web.view;
+
+import java.time.LocalDateTime;
+
+public record ServiceHealthStatus(boolean alive, String message, LocalDateTime checkedAt) {
+}

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -2,6 +2,22 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org"
       th:replace="~{layout/base :: layout(${pageTitle}, ${activeMenu}, ${breadcrumbs}, ~{::content})}">
 <th:block th:fragment="content">
+        <section class="row g-4 mb-4" th:if="${serviceHealth != null}">
+            <div class="col-12">
+                <div class="alert d-flex align-items-center mb-0"
+                     th:classappend="${serviceHealth.alive()} ? ' alert-success' : ' alert-danger'">
+                    <i class="bi fs-4"
+                       th:classappend="${serviceHealth.alive()} ? ' bi-check-circle-fill' : ' bi-exclamation-octagon-fill'"></i>
+                    <div class="ms-3">
+                        <h2 class="h6 mb-1 fw-semibold">서비스 서버 상태</h2>
+                        <p class="mb-1" th:text="${serviceHealth.message()}">서버가 정상 응답했습니다.</p>
+                        <p class="mb-0 text-muted small"
+                           th:text="${#temporals.format(serviceHealth.checkedAt(), 'yyyy.MM.dd HH:mm:ss')}"
+                        >2024.06.01 12:00:00</p>
+                    </div>
+                </div>
+            </div>
+        </section>
         <section class="row g-4 mb-4">
             <div class="col-12 col-xl-3 col-md-6" th:each="metric : ${metrics}">
                 <div class="card card-shadow-sm h-100 border-0">

--- a/src/test/java/apu/saerok_admin/infra/ServiceHealthClientTest.java
+++ b/src/test/java/apu/saerok_admin/infra/ServiceHealthClientTest.java
@@ -1,0 +1,92 @@
+package apu.saerok_admin.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import apu.saerok_admin.web.view.ServiceHealthStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@ExtendWith(MockitoExtension.class)
+class ServiceHealthClientTest {
+
+    private static final LocalDateTime FIXED_DATE_TIME = LocalDateTime.of(2024, 6, 1, 21, 0);
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private RestClient restClient;
+
+    private ServiceHealthClient client;
+    private Clock fixedClock;
+
+    @BeforeEach
+    void setUp() {
+        fixedClock = Clock.fixed(Instant.parse("2024-06-01T12:00:00Z"), ZoneId.of("Asia/Seoul"));
+        client = new ServiceHealthClient(restClient, fixedClock);
+    }
+
+    @Test
+    void checkHealthReturnsAliveStatusWithResponseMessageWhenHealthEndpointIsUp() {
+        ResponseEntity<Map<String, Object>> response = ResponseEntity.ok(Map.of("status", "UP"));
+        when(restClient.get().uri(anyString()).retrieve().toEntity(any(ParameterizedTypeReference.class)))
+                .thenReturn(response);
+
+        ServiceHealthStatus status = client.checkHealth();
+
+        assertThat(status.alive()).isTrue();
+        assertThat(status.message()).isEqualTo("상태: UP");
+        assertThat(status.checkedAt()).isEqualTo(FIXED_DATE_TIME);
+    }
+
+    @Test
+    void checkHealthReturnsDownStatusWhenHealthEndpointRespondsWithServerError() {
+        ResponseEntity<Map<String, Object>> response = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        when(restClient.get().uri(anyString()).retrieve().toEntity(any(ParameterizedTypeReference.class)))
+                .thenReturn(response);
+
+        ServiceHealthStatus status = client.checkHealth();
+
+        assertThat(status.alive()).isFalse();
+        assertThat(status.message()).isEqualTo("HTTP 상태 코드 500");
+        assertThat(status.checkedAt()).isEqualTo(FIXED_DATE_TIME);
+    }
+
+    @Test
+    void checkHealthReturnsFailureStatusWithExceptionMessageWhenRequestFails() {
+        when(restClient.get().uri(anyString()).retrieve().toEntity(any(ParameterizedTypeReference.class)))
+                .thenThrow(new RestClientException("연결 실패"));
+
+        ServiceHealthStatus status = client.checkHealth();
+
+        assertThat(status.alive()).isFalse();
+        assertThat(status.message()).isEqualTo("연결 실패");
+        assertThat(status.checkedAt()).isEqualTo(FIXED_DATE_TIME);
+    }
+
+    @Test
+    void checkHealthReturnsGenericFailureMessageWhenExceptionMessageIsBlank() {
+        when(restClient.get().uri(anyString()).retrieve().toEntity(any(ParameterizedTypeReference.class)))
+                .thenThrow(new RestClientException("   "));
+
+        ServiceHealthStatus status = client.checkHealth();
+
+        assertThat(status.alive()).isFalse();
+        assertThat(status.message()).isEqualTo("요청 중 오류가 발생했습니다.");
+        assertThat(status.checkedAt()).isEqualTo(FIXED_DATE_TIME);
+    }
+}


### PR DESCRIPTION
## Summary
- inject a system clock into `ServiceHealthClient` and expose it via configuration
- add unit tests covering success, error, and exception flows for the service health check

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d0f417825c832cab1c5e98cfc0129f