### PR TITLE
Fix service health check to handle plain text responses

### DIFF
--- a/src/main/java/apu/saerok_admin/infra/ServiceHealthClient.java
+++ b/src/main/java/apu/saerok_admin/infra/ServiceHealthClient.java
@@ -3,9 +3,6 @@ package apu.saerok_admin.infra;
 import apu.saerok_admin.web.view.ServiceHealthStatus;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.Objects;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -13,9 +10,6 @@ import org.springframework.web.client.RestClientException;
 
 @Component
 public class ServiceHealthClient {
-
-    private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
-            new ParameterizedTypeReference<>() {};
 
     private final RestClient saerokRestClient;
     private final Clock clock;
@@ -28,10 +22,10 @@ public class ServiceHealthClient {
     public ServiceHealthStatus checkHealth() {
         LocalDateTime checkedAt = LocalDateTime.now(clock);
         try {
-            ResponseEntity<Map<String, Object>> response = saerokRestClient.get()
+            ResponseEntity<String> response = saerokRestClient.get()
                     .uri("/health")
                     .retrieve()
-                    .toEntity(MAP_TYPE);
+                    .toEntity(String.class);
 
             boolean alive = response.getStatusCode().is2xxSuccessful();
             String message = alive
@@ -48,16 +42,11 @@ public class ServiceHealthClient {
         }
     }
 
-    private String extractStatusMessage(Map<String, Object> body) {
-        if (body == null || body.isEmpty()) {
+    private String extractStatusMessage(String body) {
+        if (body == null || body.isBlank()) {
             return "서버가 정상 응답했습니다.";
         }
 
-        Object status = body.get("status");
-        if (status != null) {
-            return "상태: " + Objects.toString(status);
-        }
-
-        return "서버가 정상 응답했습니다.";
+        return body;
     }
 }

--- a/src/test/java/apu/saerok_admin/infra/ServiceHealthClientTest.java
+++ b/src/test/java/apu/saerok_admin/infra/ServiceHealthClientTest.java
@@ -1,8 +1,8 @@
 package apu.saerok_admin.infra;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import apu.saerok_admin.web.view.ServiceHealthStatus;
@@ -10,14 +10,12 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
@@ -42,21 +40,34 @@ class ServiceHealthClientTest {
 
     @Test
     void checkHealthReturnsAliveStatusWithResponseMessageWhenHealthEndpointIsUp() {
-        ResponseEntity<Map<String, Object>> response = ResponseEntity.ok(Map.of("status", "UP"));
-        when(restClient.get().uri(anyString()).retrieve().toEntity(any(ParameterizedTypeReference.class)))
+        ResponseEntity<String> response = ResponseEntity.ok("I am healthy");
+        when(restClient.get().uri(anyString()).retrieve().toEntity(eq(String.class)))
                 .thenReturn(response);
 
         ServiceHealthStatus status = client.checkHealth();
 
         assertThat(status.alive()).isTrue();
-        assertThat(status.message()).isEqualTo("상태: UP");
+        assertThat(status.message()).isEqualTo("I am healthy");
+        assertThat(status.checkedAt()).isEqualTo(FIXED_DATE_TIME);
+    }
+
+    @Test
+    void checkHealthReturnsAliveStatusWithDefaultMessageWhenBodyIsBlank() {
+        ResponseEntity<String> response = ResponseEntity.ok("   ");
+        when(restClient.get().uri(anyString()).retrieve().toEntity(eq(String.class)))
+                .thenReturn(response);
+
+        ServiceHealthStatus status = client.checkHealth();
+
+        assertThat(status.alive()).isTrue();
+        assertThat(status.message()).isEqualTo("서버가 정상 응답했습니다.");
         assertThat(status.checkedAt()).isEqualTo(FIXED_DATE_TIME);
     }
 
     @Test
     void checkHealthReturnsDownStatusWhenHealthEndpointRespondsWithServerError() {
-        ResponseEntity<Map<String, Object>> response = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
-        when(restClient.get().uri(anyString()).retrieve().toEntity(any(ParameterizedTypeReference.class)))
+        ResponseEntity<String> response = ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        when(restClient.get().uri(anyString()).retrieve().toEntity(eq(String.class)))
                 .thenReturn(response);
 
         ServiceHealthStatus status = client.checkHealth();
@@ -68,7 +79,7 @@ class ServiceHealthClientTest {
 
     @Test
     void checkHealthReturnsFailureStatusWithExceptionMessageWhenRequestFails() {
-        when(restClient.get().uri(anyString()).retrieve().toEntity(any(ParameterizedTypeReference.class)))
+        when(restClient.get().uri(anyString()).retrieve().toEntity(eq(String.class)))
                 .thenThrow(new RestClientException("연결 실패"));
 
         ServiceHealthStatus status = client.checkHealth();
@@ -80,7 +91,7 @@ class ServiceHealthClientTest {
 
     @Test
     void checkHealthReturnsGenericFailureMessageWhenExceptionMessageIsBlank() {
-        when(restClient.get().uri(anyString()).retrieve().toEntity(any(ParameterizedTypeReference.class)))
+        when(restClient.get().uri(anyString()).retrieve().toEntity(eq(String.class)))
                 .thenThrow(new RestClientException("   "));
 
         ServiceHealthStatus status = client.checkHealth();


### PR DESCRIPTION
## Summary
- update the service health client to read the `/health` endpoint as plain text and keep a sensible fallback message
- refresh the unit tests to cover string responses and blank bodies

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d0fafb073c832ca7deb735841f0c74