### PR TITLE
Add BFF social login flow for Kakao and Apple

### DIFF
--- a/src/main/java/apu/saerok_admin/config/SecurityConfig.java
+++ b/src/main/java/apu/saerok_admin/config/SecurityConfig.java
@@ -1,28 +1,54 @@
 package apu.saerok_admin.config;
 
+import apu.saerok_admin.security.LoginSessionAuthenticationFilter;
+import apu.saerok_admin.security.LoginSessionManager;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            LoginSessionAuthenticationFilter loginSessionAuthenticationFilter,
+            LoginSessionManager loginSessionManager
+    ) throws Exception {
         http
-            .csrf(AbstractHttpConfigurer::disable)
-            .formLogin(AbstractHttpConfigurer::disable)
-            .httpBasic(AbstractHttpConfigurer::disable)
-            .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
-            .logout(Customizer.withDefaults());
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("/login", "/auth/callback/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login")
+                        .clearAuthentication(true)
+                        .invalidateHttpSession(true)
+                        .addLogoutHandler((request, response, authentication) -> {
+                            loginSessionManager.clearSession(request);
+                            loginSessionManager.deleteRefreshCookie(response, request.isSecure());
+                        })
+                );
+        http.addFilterAfter(loginSessionAuthenticationFilter, SecurityContextPersistenceFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public LoginSessionAuthenticationFilter loginSessionAuthenticationFilter(LoginSessionManager loginSessionManager) {
+        return new LoginSessionAuthenticationFilter(loginSessionManager);
     }
 
     @Bean

--- a/src/main/java/apu/saerok_admin/config/SocialLoginProperties.java
+++ b/src/main/java/apu/saerok_admin/config/SocialLoginProperties.java
@@ -1,0 +1,11 @@
+package apu.saerok_admin.config;
+
+import java.net.URI;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth")
+public record SocialLoginProperties(Provider kakao, Provider apple) {
+
+    public record Provider(String clientId, URI redirectUri) {
+    }
+}

--- a/src/main/java/apu/saerok_admin/infra/SaerokApiClientConfig.java
+++ b/src/main/java/apu/saerok_admin/infra/SaerokApiClientConfig.java
@@ -1,17 +1,30 @@
 package apu.saerok_admin.infra;
 
+import apu.saerok_admin.config.SocialLoginProperties;
 import java.time.Clock;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestClient;
 
 @Configuration
-@EnableConfigurationProperties(SaerokApiProps.class)
+@EnableConfigurationProperties({SaerokApiProps.class, SocialLoginProperties.class})
 public class SaerokApiClientConfig {
+
     @Bean
-    RestClient saerokRestClient(SaerokApiProps props) {
+    @Primary
+    RestClient saerokRestClient(SaerokApiProps props, ObjectProvider<ClientHttpRequestInterceptor> interceptors) {
+        RestClient.Builder builder = RestClient.builder().baseUrl(props.baseUrl());
+        interceptors.orderedStream().forEach(builder::requestInterceptor);
+        return builder.build();
+    }
+
+    @Bean(name = "saerokAuthRestClient")
+    RestClient saerokAuthRestClient(SaerokApiProps props) {
         return RestClient.builder().baseUrl(props.baseUrl()).build();
     }
 

--- a/src/main/java/apu/saerok_admin/infra/auth/BackendAuthClient.java
+++ b/src/main/java/apu/saerok_admin/infra/auth/BackendAuthClient.java
@@ -1,0 +1,103 @@
+package apu.saerok_admin.infra.auth;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class BackendAuthClient {
+
+    private final RestClient authRestClient;
+
+    public BackendAuthClient(@Qualifier("saerokAuthRestClient") RestClient authRestClient) {
+        this.authRestClient = authRestClient;
+    }
+
+    public LoginSuccess kakaoLogin(String authorizationCode) {
+        KakaoLoginPayload payload = new KakaoLoginPayload(authorizationCode);
+        ResponseEntity<BackendAccessTokenResponse> response = authRestClient.post()
+                .uri("/auth/kakao/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve()
+                .toEntity(BackendAccessTokenResponse.class);
+        return toLoginSuccess(response);
+    }
+
+    public LoginSuccess appleLogin(String authorizationCode) {
+        AppleLoginPayload payload = new AppleLoginPayload(authorizationCode);
+        ResponseEntity<BackendAccessTokenResponse> response = authRestClient.post()
+                .uri("/auth/apple/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve()
+                .toEntity(BackendAccessTokenResponse.class);
+        return toLoginSuccess(response);
+    }
+
+    public LoginSuccess refreshAccessToken() {
+        RestClient.RequestHeadersSpec<?> requestSpec = authRestClient.post()
+                .uri("/auth/refresh");
+        extractRefreshCookie().ifPresent(cookie -> requestSpec.header(HttpHeaders.COOKIE, cookie));
+        ResponseEntity<BackendAccessTokenResponse> response = requestSpec.retrieve()
+                .toEntity(BackendAccessTokenResponse.class);
+        return toLoginSuccess(response);
+    }
+
+    private Optional<String> extractRefreshCookie() {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            return Optional.empty();
+        }
+        HttpServletRequest request = attributes.getRequest();
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(cookies)
+                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                .map(cookie -> cookie.getName() + "=" + cookie.getValue())
+                .findFirst();
+    }
+
+    private LoginSuccess toLoginSuccess(ResponseEntity<BackendAccessTokenResponse> response) {
+        BackendAccessTokenResponse body = response.getBody();
+        if (body == null || !StringUtils.hasText(body.accessToken())) {
+            throw new IllegalStateException("백엔드에서 유효한 액세스 토큰을 받지 못했습니다.");
+        }
+        List<String> cookies = Optional.ofNullable(response.getHeaders().get(HttpHeaders.SET_COOKIE))
+                .map(List::copyOf)
+                .orElse(List.of());
+        return new LoginSuccess(body.accessToken(), cookies);
+    }
+
+    private record KakaoLoginPayload(String authorizationCode) {
+    }
+
+    private record AppleLoginPayload(String authorizationCode) {
+    }
+
+    private record BackendAccessTokenResponse(String accessToken, String signupStatus) {
+    }
+
+    public record LoginSuccess(String accessToken, List<String> refreshCookies) {
+
+        public LoginSuccess {
+            if (!StringUtils.hasText(accessToken)) {
+                throw new IllegalArgumentException("accessToken must not be empty");
+            }
+            refreshCookies = refreshCookies == null ? List.of() : List.copyOf(refreshCookies);
+        }
+    }
+}

--- a/src/main/java/apu/saerok_admin/infra/auth/BackendAuthorizationInterceptor.java
+++ b/src/main/java/apu/saerok_admin/infra/auth/BackendAuthorizationInterceptor.java
@@ -1,0 +1,103 @@
+package apu.saerok_admin.infra.auth;
+
+import apu.saerok_admin.security.BackendUnauthorizedException;
+import apu.saerok_admin.security.LoginSessionManager;
+import java.io.IOException;
+import java.util.Optional;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.support.HttpRequestWrapper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.ResourceAccessException;
+
+@Component
+public class BackendAuthorizationInterceptor implements ClientHttpRequestInterceptor {
+
+    private final LoginSessionManager loginSessionManager;
+    private final BackendAuthClient backendAuthClient;
+
+    public BackendAuthorizationInterceptor(LoginSessionManager loginSessionManager, BackendAuthClient backendAuthClient) {
+        this.loginSessionManager = loginSessionManager;
+        this.backendAuthClient = backendAuthClient;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
+        if (isAuthRequest(request)) {
+            return execution.execute(request, body);
+        }
+
+        HttpRequestWrapper authorizedRequest = wrapRequest(request);
+        loginSessionManager.currentAccessToken()
+                .ifPresent(token -> authorizedRequest.getHeaders().setBearerAuth(token));
+
+        ClientHttpResponse response = execution.execute(authorizedRequest, body);
+        if (response.getStatusCode() != HttpStatus.UNAUTHORIZED) {
+            return response;
+        }
+
+        response.close();
+        return retryWithRefreshedToken(request, body, execution);
+    }
+
+    private ClientHttpResponse retryWithRefreshedToken(
+            HttpRequest request,
+            byte[] body,
+            ClientHttpRequestExecution execution
+    ) throws IOException {
+        Optional<String> currentToken = loginSessionManager.currentAccessToken();
+        if (currentToken.isEmpty()) {
+            return execution.execute(request, body);
+        }
+
+        BackendAuthClient.LoginSuccess refreshedTokens;
+        try {
+            refreshedTokens = backendAuthClient.refreshAccessToken();
+        } catch (RestClientResponseException | ResourceAccessException | IllegalStateException ex) {
+            loginSessionManager.clearCurrentSession();
+            throw new BackendUnauthorizedException("토큰 갱신에 실패했습니다.", ex);
+        }
+
+        loginSessionManager.updateAccessToken(refreshedTokens.accessToken());
+        loginSessionManager.writeRefreshCookiesToResponse(refreshedTokens.refreshCookies());
+
+        HttpRequestWrapper retryRequest = wrapRequest(request);
+        loginSessionManager.currentAccessToken()
+                .ifPresent(token -> retryRequest.getHeaders().setBearerAuth(token));
+
+        ClientHttpResponse retryResponse = execution.execute(retryRequest, body);
+        if (retryResponse.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+            retryResponse.close();
+            loginSessionManager.clearCurrentSession();
+            throw new BackendUnauthorizedException("세션이 만료되었습니다. 다시 로그인해주세요.");
+        }
+
+        return retryResponse;
+    }
+
+    private boolean isAuthRequest(HttpRequest request) {
+        String path = request.getURI() != null ? request.getURI().getPath() : null;
+        return path != null && path.contains("/auth/");
+    }
+
+    private HttpRequestWrapper wrapRequest(HttpRequest request) {
+        return new HttpRequestWrapper(request) {
+            private final HttpHeaders headers = new HttpHeaders();
+
+            {
+                headers.putAll(request.getHeaders());
+            }
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return headers;
+            }
+        };
+    }
+}

--- a/src/main/java/apu/saerok_admin/security/BackendUnauthorizedException.java
+++ b/src/main/java/apu/saerok_admin/security/BackendUnauthorizedException.java
@@ -1,0 +1,12 @@
+package apu.saerok_admin.security;
+
+public class BackendUnauthorizedException extends RuntimeException {
+
+    public BackendUnauthorizedException(String message) {
+        super(message);
+    }
+
+    public BackendUnauthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/apu/saerok_admin/security/LoginSession.java
+++ b/src/main/java/apu/saerok_admin/security/LoginSession.java
@@ -1,0 +1,8 @@
+package apu.saerok_admin.security;
+
+import java.io.Serializable;
+
+public record LoginSession(String accessToken) implements Serializable {
+
+    public static final String ATTRIBUTE_NAME = "SAEROK_LOGIN_SESSION";
+}

--- a/src/main/java/apu/saerok_admin/security/LoginSessionAuthenticationFilter.java
+++ b/src/main/java/apu/saerok_admin/security/LoginSessionAuthenticationFilter.java
@@ -1,0 +1,35 @@
+package apu.saerok_admin.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class LoginSessionAuthenticationFilter extends OncePerRequestFilter {
+
+    private final LoginSessionManager loginSessionManager;
+
+    public LoginSessionAuthenticationFilter(LoginSessionManager loginSessionManager) {
+        this.loginSessionManager = loginSessionManager;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            loginSessionManager.findSession(request).ifPresent(session -> {
+                SaerokAdminAuthentication authentication = loginSessionManager.createAuthentication(session);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            });
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/apu/saerok_admin/security/LoginSessionManager.java
+++ b/src/main/java/apu/saerok_admin/security/LoginSessionManager.java
@@ -1,0 +1,148 @@
+package apu.saerok_admin.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class LoginSessionManager {
+
+    private static final String PRINCIPAL = "SaerokAdmin";
+
+    public void establishSession(HttpServletRequest request, LoginSession loginSession) {
+        HttpSession session = request.getSession(true);
+        session.setAttribute(LoginSession.ATTRIBUTE_NAME, loginSession);
+
+        SaerokAdminAuthentication authentication = createAuthentication(loginSession);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+    }
+
+    public Optional<LoginSession> findSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return Optional.empty();
+        }
+        Object attribute = session.getAttribute(LoginSession.ATTRIBUTE_NAME);
+        if (attribute instanceof LoginSession loginSession) {
+            return Optional.of(loginSession);
+        }
+        return Optional.empty();
+    }
+
+    public Optional<LoginSession> currentSession() {
+        ServletRequestAttributes attributes = currentRequestAttributes();
+        if (attributes == null) {
+            return Optional.empty();
+        }
+        HttpSession session = attributes.getRequest().getSession(false);
+        if (session == null) {
+            return Optional.empty();
+        }
+        Object attribute = session.getAttribute(LoginSession.ATTRIBUTE_NAME);
+        if (attribute instanceof LoginSession loginSession) {
+            return Optional.of(loginSession);
+        }
+        return Optional.empty();
+    }
+
+    public Optional<String> currentAccessToken() {
+        return currentSession().map(LoginSession::accessToken);
+    }
+
+    public void updateAccessToken(String accessToken) {
+        if (!StringUtils.hasText(accessToken)) {
+            clearCurrentSession();
+            return;
+        }
+        ServletRequestAttributes attributes = currentRequestAttributes();
+        if (attributes == null) {
+            return;
+        }
+        HttpServletRequest request = attributes.getRequest();
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return;
+        }
+        LoginSession updatedSession = new LoginSession(accessToken);
+        session.setAttribute(LoginSession.ATTRIBUTE_NAME, updatedSession);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof SaerokAdminAuthentication adminAuthentication) {
+            adminAuthentication.updateLoginSession(updatedSession);
+        }
+        session.setAttribute(
+                HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+                SecurityContextHolder.getContext()
+        );
+    }
+
+    public void clearSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute(LoginSession.ATTRIBUTE_NAME);
+            session.removeAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+        }
+        SecurityContextHolder.clearContext();
+    }
+
+    public void clearCurrentSession() {
+        ServletRequestAttributes attributes = currentRequestAttributes();
+        if (attributes != null) {
+            HttpSession session = attributes.getRequest().getSession(false);
+            if (session != null) {
+                session.removeAttribute(LoginSession.ATTRIBUTE_NAME);
+                session.removeAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+            }
+        }
+        SecurityContextHolder.clearContext();
+    }
+
+    public void writeRefreshCookiesToResponse(List<String> cookies) {
+        if (cookies == null || cookies.isEmpty()) {
+            return;
+        }
+        ServletRequestAttributes attributes = currentRequestAttributes();
+        if (attributes == null) {
+            return;
+        }
+        HttpServletResponse response = attributes.getResponse();
+        if (response == null) {
+            return;
+        }
+        cookies.forEach(cookie -> response.addHeader(HttpHeaders.SET_COOKIE, cookie));
+    }
+
+    public void deleteRefreshCookie(HttpServletResponse response, boolean secure) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .maxAge(Duration.ZERO)
+                .path("/")
+                .httpOnly(true)
+                .secure(secure)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public SaerokAdminAuthentication createAuthentication(LoginSession loginSession) {
+        return new SaerokAdminAuthentication(PRINCIPAL, loginSession);
+    }
+
+    private ServletRequestAttributes currentRequestAttributes() {
+        return (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+    }
+}

--- a/src/main/java/apu/saerok_admin/security/OAuthStateManager.java
+++ b/src/main/java/apu/saerok_admin/security/OAuthStateManager.java
@@ -1,0 +1,35 @@
+package apu.saerok_admin.security;
+
+import jakarta.servlet.http.HttpSession;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuthStateManager {
+
+    public static final String ATTRIBUTE_NAME = "SAEROK_OAUTH_STATE";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    public String createState(HttpSession session) {
+        String state = generateStateToken();
+        session.setAttribute(ATTRIBUTE_NAME, state);
+        return state;
+    }
+
+    public boolean consumeState(HttpSession session, String providedState) {
+        Object stored = session.getAttribute(ATTRIBUTE_NAME);
+        session.removeAttribute(ATTRIBUTE_NAME);
+        if (!(stored instanceof String storedState)) {
+            return false;
+        }
+        return Objects.equals(storedState, providedState);
+    }
+
+    private String generateStateToken() {
+        byte[] randomBytes = new byte[24];
+        SECURE_RANDOM.nextBytes(randomBytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+    }
+}

--- a/src/main/java/apu/saerok_admin/security/SaerokAdminAuthentication.java
+++ b/src/main/java/apu/saerok_admin/security/SaerokAdminAuthentication.java
@@ -1,0 +1,50 @@
+package apu.saerok_admin.security;
+
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class SaerokAdminAuthentication extends AbstractAuthenticationToken {
+
+    private final Object principal;
+    private LoginSession loginSession;
+
+    public SaerokAdminAuthentication(Object principal, LoginSession loginSession) {
+        this(principal, loginSession, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+    }
+
+    private SaerokAdminAuthentication(
+            Object principal,
+            LoginSession loginSession,
+            Collection<? extends GrantedAuthority> authorities
+    ) {
+        super(authorities);
+        this.principal = principal;
+        this.loginSession = loginSession;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return "";
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    public LoginSession getLoginSession() {
+        return loginSession;
+    }
+
+    public String getAccessToken() {
+        return loginSession.accessToken();
+    }
+
+    public void updateLoginSession(LoginSession loginSession) {
+        this.loginSession = loginSession;
+    }
+}

--- a/src/main/java/apu/saerok_admin/web/AuthController.java
+++ b/src/main/java/apu/saerok_admin/web/AuthController.java
@@ -1,15 +1,118 @@
 package apu.saerok_admin.web;
 
+import apu.saerok_admin.config.SocialLoginProperties;
+import apu.saerok_admin.infra.auth.BackendAuthClient;
+import apu.saerok_admin.security.LoginSession;
+import apu.saerok_admin.security.LoginSessionManager;
+import apu.saerok_admin.security.OAuthStateManager;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.function.Function;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Controller
-public class    AuthController {
+public class AuthController {
+
+    private final SocialLoginProperties socialLoginProperties;
+    private final OAuthStateManager oAuthStateManager;
+    private final BackendAuthClient backendAuthClient;
+    private final LoginSessionManager loginSessionManager;
+
+    public AuthController(
+            SocialLoginProperties socialLoginProperties,
+            OAuthStateManager oAuthStateManager,
+            BackendAuthClient backendAuthClient,
+            LoginSessionManager loginSessionManager
+    ) {
+        this.socialLoginProperties = socialLoginProperties;
+        this.oAuthStateManager = oAuthStateManager;
+        this.backendAuthClient = backendAuthClient;
+        this.loginSessionManager = loginSessionManager;
+    }
 
     @GetMapping("/login")
-    public String login(Model model) {
+    public String login(Model model, HttpSession session) {
+        String state = oAuthStateManager.createState(session);
         model.addAttribute("pageTitle", "로그인");
+        model.addAttribute("kakaoAuthUrl", buildKakaoAuthorizeUrl(state));
+        model.addAttribute("appleAuthUrl", buildAppleAuthorizeUrl(state));
         return "auth/login";
+    }
+
+    @GetMapping("/auth/callback/kakao")
+    public String handleKakaoCallback(
+            @RequestParam(name = "code", required = false) String code,
+            @RequestParam(name = "state", required = false) String state,
+            HttpServletRequest request,
+            HttpSession session
+    ) {
+        return handleSocialCallback(code, state, session, request, backendAuthClient::kakaoLogin);
+    }
+
+    @RequestMapping(value = "/auth/callback/apple", method = {RequestMethod.POST, RequestMethod.GET})
+    public String handleAppleCallback(
+            @RequestParam(name = "code", required = false) String code,
+            @RequestParam(name = "state", required = false) String state,
+            HttpServletRequest request,
+            HttpSession session
+    ) {
+        return handleSocialCallback(code, state, session, request, backendAuthClient::appleLogin);
+    }
+
+    private String handleSocialCallback(
+            String code,
+            String state,
+            HttpSession session,
+            HttpServletRequest request,
+            Function<String, BackendAuthClient.LoginSuccess> loginFunction
+    ) {
+        if (!StringUtils.hasText(code) || !StringUtils.hasText(state)) {
+            return "redirect:/login?error=callback";
+        }
+        if (!oAuthStateManager.consumeState(session, state)) {
+            return "redirect:/login?error=state";
+        }
+        try {
+            BackendAuthClient.LoginSuccess loginSuccess = loginFunction.apply(code);
+            loginSessionManager.establishSession(request, new LoginSession(loginSuccess.accessToken()));
+            loginSessionManager.writeRefreshCookiesToResponse(loginSuccess.refreshCookies());
+            return "redirect:/";
+        } catch (RestClientException | IllegalStateException exception) {
+            loginSessionManager.clearSession(request);
+            return "redirect:/login?error=login";
+        }
+    }
+
+    private String buildKakaoAuthorizeUrl(String state) {
+        SocialLoginProperties.Provider kakao = socialLoginProperties.kakao();
+        return UriComponentsBuilder.fromHttpUrl("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", kakao.clientId())
+                .queryParam("redirect_uri", kakao.redirectUri())
+                .queryParam("state", state)
+                .queryParam("scope", "account_email")
+                .build(true)
+                .toUriString();
+    }
+
+    private String buildAppleAuthorizeUrl(String state) {
+        SocialLoginProperties.Provider apple = socialLoginProperties.apple();
+        return UriComponentsBuilder.fromHttpUrl("https://appleid.apple.com/auth/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", apple.clientId())
+                .queryParam("redirect_uri", apple.redirectUri())
+                .queryParam("scope", "openid email name")
+                .queryParam("response_mode", "form_post")
+                .queryParam("state", state)
+                .build(true)
+                .toUriString();
     }
 }

--- a/src/main/java/apu/saerok_admin/web/AuthExceptionHandler.java
+++ b/src/main/java/apu/saerok_admin/web/AuthExceptionHandler.java
@@ -1,0 +1,22 @@
+package apu.saerok_admin.web;
+
+import apu.saerok_admin.security.BackendUnauthorizedException;
+import apu.saerok_admin.security.LoginSessionManager;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class AuthExceptionHandler {
+
+    private final LoginSessionManager loginSessionManager;
+
+    public AuthExceptionHandler(LoginSessionManager loginSessionManager) {
+        this.loginSessionManager = loginSessionManager;
+    }
+
+    @ExceptionHandler(BackendUnauthorizedException.class)
+    public String handleBackendUnauthorizedException() {
+        loginSessionManager.clearCurrentSession();
+        return "redirect:/login?error=session";
+    }
+}

--- a/src/main/resources/application-codex.yml
+++ b/src/main/resources/application-codex.yml
@@ -1,3 +1,14 @@
+server:
+  port: 8081
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID:}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8081/auth/callback/kakao}
+  apple:
+    client-id: ${APPLE_CLIENT_ID:}
+    redirect-uri: ${APPLE_REDIRECT_URI:http://localhost:8081/auth/callback/apple}
+
 saerok:
   api:
-    base-url: http://localhost:8080
+    base-url: http://localhost:8080/api/v1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,18 @@
-spring.application.name: saerok-admin
-server.port: 8081
+spring:
+  application:
+    name: saerok-admin
+
+server:
+  port: 8081
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID:}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8081/auth/callback/kakao}
+  apple:
+    client-id: ${APPLE_CLIENT_ID:}
+    redirect-uri: ${APPLE_REDIRECT_URI:http://localhost:8081/auth/callback/apple}
+
+saerok:
+  api:
+    base-url: ${SAEROK_API_BASE_URL:http://localhost:8080/api/v1}

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -13,48 +13,31 @@
         </div>
         <div class="alert alert-danger d-flex align-items-start" role="alert" th:if="${param.error}">
             <i class="bi bi-exclamation-triangle-fill me-2"></i>
-            <div>로그인 정보가 올바르지 않습니다. 다시 시도해주세요.</div>
+            <div th:switch="${param.error[0]}">
+                <span th:case="'state'">보안 검증에 실패했습니다. 다시 로그인해주세요.</span>
+                <span th:case="'callback'">필수 인증 정보가 누락되었습니다. 다시 시도해주세요.</span>
+                <span th:case="'session'">세션이 만료되었습니다. 다시 로그인해주세요.</span>
+                <span th:case="'login'">로그인 중 오류가 발생했습니다. 다시 시도해주세요.</span>
+                <span th:case="*">로그인에 실패했습니다. 다시 시도해주세요.</span>
+            </div>
         </div>
-        <form th:action="@{/}" method="get" class="needs-validation" novalidate>
-            <div class="mb-3">
-                <label for="email" class="form-label fw-semibold">이메일</label>
-                <input type="email" class="form-control form-control-lg" id="email" name="email" placeholder="admin@saerok.app" required>
-                <div class="invalid-feedback">이메일을 입력해주세요.</div>
-            </div>
-            <div class="mb-3">
-                <label for="password" class="form-label fw-semibold">비밀번호</label>
-                <input type="password" class="form-control form-control-lg" id="password" name="password" placeholder="••••••••" required>
-                <div class="invalid-feedback">비밀번호를 입력해주세요.</div>
-            </div>
-            <div class="d-flex justify-content-between align-items-center mb-4">
-                <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="remember">
-                    <label class="form-check-label" for="remember">로그인 상태 유지</label>
-                </div>
-                <a href="#" class="small text-decoration-none">비밀번호 재설정</a>
-            </div>
-            <div class="d-grid">
-                <button type="submit" class="btn btn-primary btn-lg">로그인</button>
-            </div>
-        </form>
+        <div class="d-grid gap-3">
+            <a th:href="${kakaoAuthUrl}" class="btn btn-lg w-100 d-flex align-items-center justify-content-center gap-2" role="button"
+               style="background-color: #FEE500; color: #191600;" aria-label="카카오 계정으로 로그인">
+                <img src="https://t1.kakaocdn.net/kakaocorp/kakaocorp/admin/contents_social/kakao_symbol.png" alt="카카오 심볼" width="20" height="20">
+                <span class="fw-semibold">카카오로 로그인</span>
+            </a>
+            <a th:href="${appleAuthUrl}" class="btn btn-lg w-100 d-flex align-items-center justify-content-center gap-2"
+               style="background-color: #000000; color: #ffffff;" role="button" aria-label="Sign in with Apple">
+                <i class="bi bi-apple fs-4" aria-hidden="true"></i>
+                <span class="fw-semibold">Sign in with Apple</span>
+            </a>
+        </div>
+        <p class="text-muted small mt-4 mb-0 text-center">로그인을 진행하면 새록 운영을 위한 개인정보 처리에 동의하게 됩니다.</p>
     </div>
     <div class="card-footer text-center small text-muted bg-white border-0 pb-4">
         © 2025 Saerok Ops Team
     </div>
 </div>
-<script>
-    (() => {
-        const forms = document.querySelectorAll('.needs-validation');
-        Array.from(forms).forEach(form => {
-            form.addEventListener('submit', event => {
-                if (!form.checkValidity()) {
-                    event.preventDefault();
-                    event.stopPropagation();
-                }
-                form.classList.add('was-validated');
-            }, false);
-        });
-    })();
-</script>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/_navbar.html
+++ b/src/main/resources/templates/fragments/_navbar.html
@@ -33,7 +33,13 @@
                     <li><a class="dropdown-item" href="#">프로필</a></li>
                     <li><a class="dropdown-item" href="#">환경 설정</a></li>
                     <li><hr class="dropdown-divider"></li>
-                    <li><a class="dropdown-item text-danger" th:href="@{/login}"><i class="bi bi-box-arrow-right me-2"></i>로그아웃</a></li>
+                    <li>
+                        <form th:action="@{/logout}" method="post">
+                            <button type="submit" class="dropdown-item text-danger w-100">
+                                <i class="bi bi-box-arrow-right me-2"></i>로그아웃
+                            </button>
+                        </form>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/src/test/java/apu/saerok_admin/infra/auth/BackendAuthorizationInterceptorTest.java
+++ b/src/test/java/apu/saerok_admin/infra/auth/BackendAuthorizationInterceptorTest.java
@@ -1,0 +1,108 @@
+package apu.saerok_admin.infra.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import apu.saerok_admin.security.BackendUnauthorizedException;
+import apu.saerok_admin.security.LoginSession;
+import apu.saerok_admin.security.LoginSessionManager;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class BackendAuthorizationInterceptorTest {
+
+    private BackendAuthClient backendAuthClient;
+    private LoginSessionManager loginSessionManager;
+    private BackendAuthorizationInterceptor interceptor;
+    private MockHttpServletRequest servletRequest;
+    private MockHttpServletResponse servletResponse;
+
+    @BeforeEach
+    void setUp() {
+        backendAuthClient = mock(BackendAuthClient.class);
+        loginSessionManager = new LoginSessionManager();
+        interceptor = new BackendAuthorizationInterceptor(loginSessionManager, backendAuthClient);
+        servletRequest = new MockHttpServletRequest();
+        servletResponse = new MockHttpServletResponse();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(servletRequest, servletResponse));
+        HttpSession session = servletRequest.getSession(true);
+        session.setAttribute(LoginSession.ATTRIBUTE_NAME, new LoginSession("old-token"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void attachesBearerTokenAndRefreshesWhenUnauthorized() throws IOException {
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, "http://localhost/api/resource");
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        MockClientHttpResponse unauthorized = new MockClientHttpResponse(new byte[0], HttpStatus.UNAUTHORIZED);
+        MockClientHttpResponse success = new MockClientHttpResponse(new byte[0], HttpStatus.OK);
+        org.mockito.Mockito.when(execution.execute(any(HttpRequest.class), any(byte[].class)))
+                .thenReturn(unauthorized)
+                .thenReturn(success);
+        List<String> cookies = List.of("refreshToken=new; Path=/; HttpOnly");
+        org.mockito.Mockito.when(backendAuthClient.refreshAccessToken())
+                .thenReturn(new BackendAuthClient.LoginSuccess("new-token", cookies));
+
+        ClientHttpResponse response = interceptor.intercept(request, new byte[0], execution);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(execution, times(2)).execute(requestCaptor.capture(), any(byte[].class));
+        List<HttpRequest> captured = requestCaptor.getAllValues();
+        assertThat(captured.get(0).getHeaders().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer old-token");
+        assertThat(captured.get(1).getHeaders().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer new-token");
+        assertThat(servletResponse.getHeaderValues(HttpHeaders.SET_COOKIE)).containsExactlyElementsOf(cookies);
+        LoginSession updated = (LoginSession) servletRequest.getSession(false).getAttribute(LoginSession.ATTRIBUTE_NAME);
+        assertThat(updated.accessToken()).isEqualTo("new-token");
+    }
+
+    @Test
+    void clearsSessionAndThrowsWhenRefreshFails() throws IOException {
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, "http://localhost/api/metrics");
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        MockClientHttpResponse unauthorized = new MockClientHttpResponse(new byte[0], HttpStatus.UNAUTHORIZED);
+        org.mockito.Mockito.when(execution.execute(any(HttpRequest.class), any(byte[].class))).thenReturn(unauthorized);
+        org.mockito.Mockito.when(backendAuthClient.refreshAccessToken())
+                .thenThrow(new RestClientResponseException("unauthorized", HttpStatus.UNAUTHORIZED.value(), "Unauthorized", null, null, null));
+
+        assertThatThrownBy(() -> interceptor.intercept(request, new byte[0], execution))
+                .isInstanceOf(BackendUnauthorizedException.class);
+
+        verify(execution, times(1)).execute(any(HttpRequest.class), any(byte[].class));
+        verifyNoMoreInteractions(execution);
+        HttpSession session = servletRequest.getSession(false);
+        if (session != null) {
+            assertThat(session.getAttribute(LoginSession.ATTRIBUTE_NAME)).isNull();
+        }
+        assertThat(servletResponse.getHeader(HttpHeaders.SET_COOKIE)).isNull();
+    }
+}

--- a/src/test/java/apu/saerok_admin/web/AuthControllerTest.java
+++ b/src/test/java/apu/saerok_admin/web/AuthControllerTest.java
@@ -1,0 +1,123 @@
+package apu.saerok_admin.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import apu.saerok_admin.config.SocialLoginProperties;
+import apu.saerok_admin.infra.auth.BackendAuthClient;
+import apu.saerok_admin.security.LoginSession;
+import apu.saerok_admin.security.LoginSessionManager;
+import apu.saerok_admin.security.OAuthStateManager;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({OAuthStateManager.class, AuthControllerTest.TestConfig.class})
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BackendAuthClient backendAuthClient;
+
+    @MockBean
+    private LoginSessionManager loginSessionManager;
+
+    private MockHttpSession session;
+
+    @BeforeEach
+    void setUp() {
+        session = new MockHttpSession();
+    }
+
+    @Test
+    void kakaoCallbackExchangesCodeAndEstablishesSession() throws Exception {
+        session.setAttribute(OAuthStateManager.ATTRIBUTE_NAME, "expected-state");
+        List<String> cookies = List.of("refreshToken=abc; Path=/; HttpOnly");
+        BackendAuthClient.LoginSuccess loginSuccess = new BackendAuthClient.LoginSuccess("access-token", cookies);
+        given(backendAuthClient.kakaoLogin("auth-code")).willReturn(loginSuccess);
+
+        mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/auth/callback/kakao")
+                                .param("code", "auth-code")
+                                .param("state", "expected-state")
+                                .session(session)
+                )
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isFound())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl("/"));
+
+        ArgumentCaptor<LoginSession> sessionCaptor = ArgumentCaptor.forClass(LoginSession.class);
+        verify(loginSessionManager).establishSession(any(HttpServletRequest.class), sessionCaptor.capture());
+        assertThat(sessionCaptor.getValue().accessToken()).isEqualTo("access-token");
+        verify(loginSessionManager).writeRefreshCookiesToResponse(cookies);
+    }
+
+    @Test
+    void kakaoCallbackWithInvalidStateRedirectsToLoginError() throws Exception {
+        session.setAttribute(OAuthStateManager.ATTRIBUTE_NAME, "expected-state");
+
+        mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/auth/callback/kakao")
+                                .param("code", "auth-code")
+                                .param("state", "different")
+                                .session(session)
+                )
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isFound())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl("/login?error=state"));
+
+        verifyNoInteractions(backendAuthClient);
+        verify(loginSessionManager, never()).establishSession(any(HttpServletRequest.class), any(LoginSession.class));
+    }
+
+    @Test
+    void appleCallbackAcceptsFormPost() throws Exception {
+        session.setAttribute(OAuthStateManager.ATTRIBUTE_NAME, "state-token");
+        List<String> cookies = List.of("refreshToken=xyz; Path=/; HttpOnly");
+        BackendAuthClient.LoginSuccess loginSuccess = new BackendAuthClient.LoginSuccess("apple-token", cookies);
+        given(backendAuthClient.appleLogin("apple-code")).willReturn(loginSuccess);
+
+        mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post("/auth/callback/apple")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .param("code", "apple-code")
+                                .param("state", "state-token")
+                                .session(session)
+                )
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isFound())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl("/"));
+
+        verify(loginSessionManager).establishSession(any(HttpServletRequest.class), eq(new LoginSession("apple-token")));
+        verify(loginSessionManager).writeRefreshCookiesToResponse(cookies);
+    }
+
+    static class TestConfig {
+
+        @Bean
+        SocialLoginProperties socialLoginProperties() {
+            return new SocialLoginProperties(
+                    new SocialLoginProperties.Provider("kakao-client", URI.create("http://localhost/auth/callback/kakao")),
+                    new SocialLoginProperties.Provider("apple-client", URI.create("http://localhost/auth/callback/apple"))
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement Kakao and Apple callback handling that stores backend tokens in the admin session and validates OAuth state
- add a RestClient interceptor and supporting security/session utilities to attach backend access tokens, refresh them, and clear sessions on failure
- replace the login form with provider buttons, expose OAuth configuration properties, and cover the flow with controller/interceptor unit tests

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d35c544e80832ca60455599bc5bf3a