### PR TITLE
Fix social login redirect loop

### DIFF
--- a/src/main/java/apu/saerok_admin/web/AuthController.java
+++ b/src/main/java/apu/saerok_admin/web/AuthController.java
@@ -99,7 +99,7 @@ public class AuthController {
                 .queryParam("redirect_uri", kakao.redirectUri())
                 .queryParam("state", state)
                 .queryParam("scope", "account_email")
-                .build(true)
+                .encode()
                 .toUriString();
     }
 
@@ -112,7 +112,7 @@ public class AuthController {
                 .queryParam("scope", "openid email name")
                 .queryParam("response_mode", "form_post")
                 .queryParam("state", state)
-                .build(true)
+                .encode()
                 .toUriString();
     }
 }


### PR DESCRIPTION
## Summary
- encode the generated Kakao and Apple OAuth authorize URLs to avoid invalid query parameter characters
- prevent the login page from throwing and triggering an infinite redirect loop when scopes include spaces

## Testing
- ./gradlew clean build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d390d3bc64832cba5df1f18b21f353