### PR TITLE
Add detailed logging for social login flow

### DIFF
--- a/src/main/java/apu/saerok_admin/infra/auth/BackendAuthClient.java
+++ b/src/main/java/apu/saerok_admin/infra/auth/BackendAuthClient.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -18,6 +20,8 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Component
 public class BackendAuthClient {
 
+    private static final Logger log = LoggerFactory.getLogger(BackendAuthClient.class);
+
     private final RestClient authRestClient;
 
     public BackendAuthClient(@Qualifier("saerokAuthRestClient") RestClient authRestClient) {
@@ -26,23 +30,27 @@ public class BackendAuthClient {
 
     public LoginSuccess kakaoLogin(String authorizationCode) {
         KakaoLoginPayload payload = new KakaoLoginPayload(authorizationCode);
+        log.info("Requesting Kakao login from backend with authorization code length {}", authorizationCode == null ? 0 : authorizationCode.length());
         ResponseEntity<BackendAccessTokenResponse> response = authRestClient.post()
                 .uri("/auth/kakao/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(payload)
                 .retrieve()
                 .toEntity(BackendAccessTokenResponse.class);
+        log.debug("Received Kakao login response with status {} and cookies {}", response.getStatusCode(), response.getHeaders().get(HttpHeaders.SET_COOKIE));
         return toLoginSuccess(response);
     }
 
     public LoginSuccess appleLogin(String authorizationCode) {
         AppleLoginPayload payload = new AppleLoginPayload(authorizationCode);
+        log.info("Requesting Apple login from backend with authorization code length {}", authorizationCode == null ? 0 : authorizationCode.length());
         ResponseEntity<BackendAccessTokenResponse> response = authRestClient.post()
                 .uri("/auth/apple/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(payload)
                 .retrieve()
                 .toEntity(BackendAccessTokenResponse.class);
+        log.debug("Received Apple login response with status {} and cookies {}", response.getStatusCode(), response.getHeaders().get(HttpHeaders.SET_COOKIE));
         return toLoginSuccess(response);
     }
 
@@ -52,6 +60,7 @@ public class BackendAuthClient {
         extractRefreshCookie().ifPresent(cookie -> requestSpec.header(HttpHeaders.COOKIE, cookie));
         ResponseEntity<BackendAccessTokenResponse> response = requestSpec.retrieve()
                 .toEntity(BackendAccessTokenResponse.class);
+        log.debug("Refresh token request completed with status {}", response.getStatusCode());
         return toLoginSuccess(response);
     }
 
@@ -74,11 +83,14 @@ public class BackendAuthClient {
     private LoginSuccess toLoginSuccess(ResponseEntity<BackendAccessTokenResponse> response) {
         BackendAccessTokenResponse body = response.getBody();
         if (body == null || !StringUtils.hasText(body.accessToken())) {
+            log.error("Backend response did not contain a valid access token. Response body: {}", body);
             throw new IllegalStateException("백엔드에서 유효한 액세스 토큰을 받지 못했습니다.");
         }
         List<String> cookies = Optional.ofNullable(response.getHeaders().get(HttpHeaders.SET_COOKIE))
                 .map(List::copyOf)
                 .orElse(List.of());
+        log.debug("Converted backend response to LoginSuccess. accessTokenPresent={}, refreshCookieCount={}",
+                StringUtils.hasText(body.accessToken()), cookies.size());
         return new LoginSuccess(body.accessToken(), cookies);
     }
 


### PR DESCRIPTION
## Summary
- add structured logging in `AuthController` to trace OAuth state handling, backend calls, and failure reasons
- add logging in `BackendAuthClient` to observe request payload metadata, backend responses, and token validation issues

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d393f4fd88832c96c40d46a2ee7da0