### PR TITLE
Fix social login endpoints to respect API prefix

### DIFF
--- a/src/main/java/apu/saerok_admin/infra/auth/BackendAuthClient.java
+++ b/src/main/java/apu/saerok_admin/infra/auth/BackendAuthClient.java
@@ -32,7 +32,7 @@ public class BackendAuthClient {
         KakaoLoginPayload payload = new KakaoLoginPayload(authorizationCode);
         log.info("Requesting Kakao login from backend with authorization code length {}", authorizationCode == null ? 0 : authorizationCode.length());
         ResponseEntity<BackendAccessTokenResponse> response = authRestClient.post()
-                .uri("/auth/kakao/login")
+                .uri(uriBuilder -> uriBuilder.pathSegment("auth", "kakao", "login").build())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(payload)
                 .retrieve()
@@ -45,7 +45,7 @@ public class BackendAuthClient {
         AppleLoginPayload payload = new AppleLoginPayload(authorizationCode);
         log.info("Requesting Apple login from backend with authorization code length {}", authorizationCode == null ? 0 : authorizationCode.length());
         ResponseEntity<BackendAccessTokenResponse> response = authRestClient.post()
-                .uri("/auth/apple/login")
+                .uri(uriBuilder -> uriBuilder.pathSegment("auth", "apple", "login").build())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(payload)
                 .retrieve()
@@ -56,7 +56,7 @@ public class BackendAuthClient {
 
     public LoginSuccess refreshAccessToken() {
         RestClient.RequestHeadersSpec<?> requestSpec = authRestClient.post()
-                .uri("/auth/refresh");
+                .uri(uriBuilder -> uriBuilder.pathSegment("auth", "refresh").build());
         extractRefreshCookie().ifPresent(cookie -> requestSpec.header(HttpHeaders.COOKIE, cookie));
         ResponseEntity<BackendAccessTokenResponse> response = requestSpec.retrieve()
                 .toEntity(BackendAccessTokenResponse.class);

--- a/src/test/java/apu/saerok_admin/infra/auth/BackendAuthClientTest.java
+++ b/src/test/java/apu/saerok_admin/infra/auth/BackendAuthClientTest.java
@@ -1,0 +1,61 @@
+package apu.saerok_admin.infra.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+class BackendAuthClientTest {
+
+    private WireMockServer wireMockServer;
+    private BackendAuthClient backendAuthClient;
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        RestClient restClient = RestClient.builder()
+                .baseUrl("http://localhost:" + wireMockServer.port() + "/api/v1")
+                .requestFactory(new SimpleClientHttpRequestFactory())
+                .build();
+        backendAuthClient = new BackendAuthClient(restClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    @Test
+    void kakaoLoginSendsRequestIncludingApiPrefix() {
+        wireMockServer.stubFor(post(urlEqualTo("/api/v1/auth/kakao/login"))
+                .withRequestBody(equalToJson("{" +
+                        "\"authorizationCode\":\"auth-code\"" +
+                        "}"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withHeader("Set-Cookie", "refreshToken=abc; Path=/; HttpOnly")
+                        .withBody("{" +
+                                "\"accessToken\":\"backend-token\"," +
+                                "\"signupStatus\":\"COMPLETED\"" +
+                                "}")));
+
+        BackendAuthClient.LoginSuccess loginSuccess = backendAuthClient.kakaoLogin("auth-code");
+
+        assertThat(loginSuccess.accessToken()).isEqualTo("backend-token");
+        assertThat(loginSuccess.refreshCookies()).contains("refreshToken=abc; Path=/; HttpOnly");
+
+        wireMockServer.verify(postRequestedFor(urlEqualTo("/api/v1/auth/kakao/login")));
+    }
+}


### PR DESCRIPTION
## Summary
- build the social login and refresh requests with URI path segments so the backend API prefix is preserved
- add a WireMock-based test covering the Kakao login flow and verifying the correct path and cookies

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d3a9cdbc58832cacb8a1dbb5513b8a