### PR TITLE
Handle missing session for social callbacks

### DIFF
--- a/src/main/java/apu/saerok_admin/security/OAuthStateManager.java
+++ b/src/main/java/apu/saerok_admin/security/OAuthStateManager.java
@@ -19,6 +19,9 @@ public class OAuthStateManager {
     }
 
     public boolean consumeState(HttpSession session, String providedState) {
+        if (session == null) {
+            return false;
+        }
         Object stored = session.getAttribute(ATTRIBUTE_NAME);
         session.removeAttribute(ATTRIBUTE_NAME);
         if (!(stored instanceof String storedState)) {

--- a/src/main/java/apu/saerok_admin/web/AuthController.java
+++ b/src/main/java/apu/saerok_admin/web/AuthController.java
@@ -56,29 +56,31 @@ public class AuthController {
     public String handleKakaoCallback(
             @RequestParam(name = "code", required = false) String code,
             @RequestParam(name = "state", required = false) String state,
-            HttpServletRequest request,
-            HttpSession session
+            HttpServletRequest request
     ) {
-        return handleSocialCallback(code, state, session, request, backendAuthClient::kakaoLogin);
+        return handleSocialCallback(request, code, state, backendAuthClient::kakaoLogin);
     }
 
     @RequestMapping(value = "/auth/callback/apple", method = {RequestMethod.POST, RequestMethod.GET})
     public String handleAppleCallback(
             @RequestParam(name = "code", required = false) String code,
             @RequestParam(name = "state", required = false) String state,
-            HttpServletRequest request,
-            HttpSession session
+            HttpServletRequest request
     ) {
-        return handleSocialCallback(code, state, session, request, backendAuthClient::appleLogin);
+        return handleSocialCallback(request, code, state, backendAuthClient::appleLogin);
     }
 
     private String handleSocialCallback(
+            HttpServletRequest request,
             String code,
             String state,
-            HttpSession session,
-            HttpServletRequest request,
             Function<String, BackendAuthClient.LoginSuccess> loginFunction
     ) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            log.warn("OAuth callback received without an existing session. Redirecting to login with session error.");
+            return "redirect:/login?error=session";
+        }
         if (!StringUtils.hasText(code) || !StringUtils.hasText(state)) {
             log.warn("OAuth callback received without required parameters. codePresent={}, statePresent={}",
                     StringUtils.hasText(code), StringUtils.hasText(state));

--- a/src/test/java/apu/saerok_admin/web/AuthControllerTest.java
+++ b/src/test/java/apu/saerok_admin/web/AuthControllerTest.java
@@ -90,6 +90,20 @@ class AuthControllerTest {
     }
 
     @Test
+    void socialCallbackWithoutExistingSessionRedirectsToSessionError() throws Exception {
+        mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/auth/callback/kakao")
+                                .param("code", "auth-code")
+                                .param("state", "expected-state")
+                )
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isFound())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl("/login?error=session"));
+
+        verifyNoInteractions(backendAuthClient);
+        verifyNoInteractions(loginSessionManager);
+    }
+
+    @Test
     void appleCallbackAcceptsFormPost() throws Exception {
         session.setAttribute(OAuthStateManager.ATTRIBUTE_NAME, "state-token");
         List<String> cookies = List.of("refreshToken=xyz; Path=/; HttpOnly");


### PR DESCRIPTION
## Summary
- ensure social login callbacks only proceed when an existing session is present and update method signatures accordingly
- make OAuthStateManager resilient to null sessions when validating state tokens
- cover the new session guard with controller tests

## Testing
- ./gradlew test --tests apu.saerok_admin.web.AuthControllerTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68de0f30bfc4832c9ade5957b69ec0d4