### PR TITLE
Handle HEAD login requests without creating OAuth state

### DIFF
--- a/src/main/java/apu/saerok_admin/web/AuthController.java
+++ b/src/main/java/apu/saerok_admin/web/AuthController.java
@@ -6,10 +6,12 @@ import apu.saerok_admin.security.LoginSession;
 import apu.saerok_admin.security.LoginSessionManager;
 import apu.saerok_admin.security.OAuthStateManager;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.util.StringUtils;
@@ -42,13 +44,39 @@ public class AuthController {
         this.loginSessionManager = loginSessionManager;
     }
 
-    @GetMapping("/login")
-    public String login(Model model, HttpSession session) {
-        String state = oAuthStateManager.createState(session);
-        log.debug("Created OAuth state token for session {}", session.getId());
+    @RequestMapping(value = "/login", method = {RequestMethod.GET, RequestMethod.HEAD})
+    public String login(HttpServletRequest request, HttpServletResponse response, Model model) {
         model.addAttribute("pageTitle", "로그인");
-        model.addAttribute("kakaoAuthUrl", buildKakaoAuthorizeUrl(state));
-        model.addAttribute("appleAuthUrl", buildAppleAuthorizeUrl(state));
+
+        String state;
+        if (HttpMethod.HEAD.matches(request.getMethod())) {
+            response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+            response.setHeader("Pragma", "no-cache");
+            response.setDateHeader("Expires", 0);
+
+            HttpSession existingSession = request.getSession(false);
+            if (existingSession != null) {
+                state = (String) existingSession.getAttribute(OAuthStateManager.ATTRIBUTE_NAME);
+                log.debug("HEAD /login request reusing OAuth state token for session {}", existingSession.getId());
+            } else {
+                state = null;
+                log.debug("HEAD /login request without existing session; skipping OAuth state token creation.");
+            }
+        } else {
+            HttpSession session = request.getSession(true);
+            String existingState = (String) session.getAttribute(OAuthStateManager.ATTRIBUTE_NAME);
+            if (existingState == null) {
+                state = oAuthStateManager.createState(session);
+                log.debug("Created new OAuth state token for session {}", session.getId());
+            } else {
+                state = existingState;
+                log.debug("Reusing existing OAuth state token for session {}", session.getId());
+            }
+        }
+
+        String effectiveState = state != null ? state : "";
+        model.addAttribute("kakaoAuthUrl", buildKakaoAuthorizeUrl(effectiveState));
+        model.addAttribute("appleAuthUrl", buildAppleAuthorizeUrl(effectiveState));
         return "auth/login";
     }
 

--- a/src/test/java/apu/saerok_admin/web/AuthControllerTest.java
+++ b/src/test/java/apu/saerok_admin/web/AuthControllerTest.java
@@ -124,6 +124,27 @@ class AuthControllerTest {
         verify(loginSessionManager).writeRefreshCookiesToResponse(cookies);
     }
 
+    @Test
+    void headRequestDoesNotMutateSessionState() throws Exception {
+        mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/login")
+                                .session(session)
+                )
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isOk())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.view().name("auth/login"));
+
+        String state = (String) session.getAttribute(OAuthStateManager.ATTRIBUTE_NAME);
+        assertThat(state).isNotNull();
+
+        mockMvc.perform(
+                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head("/login")
+                                .session(session)
+                )
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.status().isOk());
+
+        assertThat(session.getAttribute(OAuthStateManager.ATTRIBUTE_NAME)).isEqualTo(state);
+    }
+
     static class TestConfig {
 
         @Bean


### PR DESCRIPTION
## Summary
- handle HEAD /login requests without creating new OAuth state tokens and send cache headers
- reuse existing OAuth state tokens during GET /login requests when present and update debug logging
- add a WebMvc test ensuring a HEAD probe leaves the session state untouched after a GET login

## Testing
- ./gradlew test --tests apu.saerok_admin.web.AuthControllerTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68de19bdbe6c832cbe1e1b74b2e480f3