### PR TITLE
Fetch current admin profile for navbar

### DIFF
--- a/src/main/java/apu/saerok_admin/infra/CurrentAdminClient.java
+++ b/src/main/java/apu/saerok_admin/infra/CurrentAdminClient.java
@@ -1,0 +1,83 @@
+package apu.saerok_admin.infra;
+
+import apu.saerok_admin.security.LoginSessionManager;
+import apu.saerok_admin.web.view.CurrentAdminProfile;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.util.UriBuilder;
+
+@Component
+public class CurrentAdminClient {
+
+    private static final Logger log = LoggerFactory.getLogger(CurrentAdminClient.class);
+
+    private final RestClient saerokRestClient;
+    private final List<String> missingPrefixSegments;
+    private final LoginSessionManager loginSessionManager;
+
+    public CurrentAdminClient(
+            RestClient saerokRestClient,
+            SaerokApiProps saerokApiProps,
+            LoginSessionManager loginSessionManager
+    ) {
+        this.saerokRestClient = saerokRestClient;
+        this.missingPrefixSegments = saerokApiProps.missingPrefixSegments();
+        this.loginSessionManager = loginSessionManager;
+    }
+
+    public Optional<CurrentAdminProfile> fetchCurrentAdminProfile() {
+        if (loginSessionManager.currentAccessToken().isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            BackendUserProfileResponse response = saerokRestClient.get()
+                    .uri(uriBuilder -> buildUri(uriBuilder, "user", "me"))
+                    .retrieve()
+                    .body(BackendUserProfileResponse.class);
+
+            if (response == null) {
+                return Optional.empty();
+            }
+
+            return Optional.of(new CurrentAdminProfile(
+                    response.nickname(),
+                    response.email(),
+                    response.profileImageUrl()
+            ));
+        } catch (RestClientResponseException exception) {
+            log.warn(
+                    "Failed to fetch current admin profile. status={}, body={}",
+                    exception.getStatusCode(),
+                    exception.getResponseBodyAsString(),
+                    exception
+            );
+        } catch (RestClientException exception) {
+            log.warn("Failed to fetch current admin profile.", exception);
+        }
+
+        return Optional.empty();
+    }
+
+    private URI buildUri(UriBuilder builder, String... segments) {
+        if (!missingPrefixSegments.isEmpty()) {
+            builder.pathSegment(missingPrefixSegments.toArray(String[]::new));
+        }
+        builder.pathSegment(segments);
+        return builder.build();
+    }
+
+    private record BackendUserProfileResponse(
+            String nickname,
+            String email,
+            String profileImageUrl
+    ) {
+    }
+}

--- a/src/main/java/apu/saerok_admin/web/CurrentAdminProfileAdvice.java
+++ b/src/main/java/apu/saerok_admin/web/CurrentAdminProfileAdvice.java
@@ -1,0 +1,22 @@
+package apu.saerok_admin.web;
+
+import apu.saerok_admin.infra.CurrentAdminClient;
+import apu.saerok_admin.web.view.CurrentAdminProfile;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+public class CurrentAdminProfileAdvice {
+
+    private final CurrentAdminClient currentAdminClient;
+
+    public CurrentAdminProfileAdvice(CurrentAdminClient currentAdminClient) {
+        this.currentAdminClient = currentAdminClient;
+    }
+
+    @ModelAttribute("currentAdminProfile")
+    public CurrentAdminProfile currentAdminProfile() {
+        return currentAdminClient.fetchCurrentAdminProfile()
+                .orElseGet(CurrentAdminProfile::placeholder);
+    }
+}

--- a/src/main/java/apu/saerok_admin/web/view/CurrentAdminProfile.java
+++ b/src/main/java/apu/saerok_admin/web/view/CurrentAdminProfile.java
@@ -1,0 +1,21 @@
+package apu.saerok_admin.web.view;
+
+import org.springframework.util.StringUtils;
+
+public record CurrentAdminProfile(String nickname, String email, String profileImageUrl) {
+
+    private static final String DEFAULT_PROFILE_IMAGE_URL =
+            "https://images.unsplash.com/photo-1524504388940-b1c1722653e1";
+    private static final String DEFAULT_NICKNAME = "운영자";
+    private static final String DEFAULT_EMAIL = "admin@saerok.app";
+
+    public CurrentAdminProfile {
+        nickname = StringUtils.hasText(nickname) ? nickname : DEFAULT_NICKNAME;
+        email = StringUtils.hasText(email) ? email : DEFAULT_EMAIL;
+        profileImageUrl = StringUtils.hasText(profileImageUrl) ? profileImageUrl : DEFAULT_PROFILE_IMAGE_URL;
+    }
+
+    public static CurrentAdminProfile placeholder() {
+        return new CurrentAdminProfile(null, null, null);
+    }
+}

--- a/src/main/resources/templates/fragments/_navbar.html
+++ b/src/main/resources/templates/fragments/_navbar.html
@@ -22,10 +22,10 @@
             </button>
             <div class="dropdown">
                 <a class="d-flex align-items-center text-decoration-none" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                    <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1" alt="관리자" class="rounded-circle" width="40" height="40">
+                    <img th:src="${currentAdminProfile.profileImageUrl()}" th:alt="${currentAdminProfile.nickname()}" src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1" alt="관리자" class="rounded-circle" width="40" height="40">
                     <div class="ms-2 text-start">
-                        <div class="fw-semibold">운영자</div>
-                        <small class="text-muted">admin@saerok.app</small>
+                        <div class="fw-semibold" th:text="${currentAdminProfile.nickname()}">운영자</div>
+                        <small class="text-muted" th:text="${currentAdminProfile.email()}">admin@saerok.app</small>
                     </div>
                     <i class="bi bi-chevron-down ms-2"></i>
                 </a>

--- a/src/test/java/apu/saerok_admin/web/AuthControllerTest.java
+++ b/src/test/java/apu/saerok_admin/web/AuthControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import apu.saerok_admin.config.SocialLoginProperties;
+import apu.saerok_admin.infra.CurrentAdminClient;
 import apu.saerok_admin.infra.auth.BackendAuthClient;
 import apu.saerok_admin.security.LoginSession;
 import apu.saerok_admin.security.LoginSessionManager;
@@ -16,6 +17,7 @@ import apu.saerok_admin.security.OAuthStateManager;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -43,11 +45,15 @@ class AuthControllerTest {
     @MockBean
     private LoginSessionManager loginSessionManager;
 
+    @MockBean
+    private CurrentAdminClient currentAdminClient;
+
     private MockHttpSession session;
 
     @BeforeEach
     void setUp() {
         session = new MockHttpSession();
+        given(currentAdminClient.fetchCurrentAdminProfile()).willReturn(Optional.empty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a client for calling the backend /user/me endpoint and exposing the current admin profile
- share the fetched profile with Thymeleaf through a controller advice and view model so the navbar renders real user data
- update the navbar template and existing auth controller test to work with the new profile dependency

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68de3819dff4832ca945ddc1ed3b6c89