### PR TITLE
Show backend login error message

### DIFF
--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -17,7 +17,10 @@
                 <span th:case="'state'">보안 검증에 실패했습니다. 다시 로그인해주세요.</span>
                 <span th:case="'callback'">필수 인증 정보가 누락되었습니다. 다시 시도해주세요.</span>
                 <span th:case="'session'">세션이 만료되었습니다. 다시 로그인해주세요.</span>
-                <span th:case="'login'">로그인 중 오류가 발생했습니다. 다시 시도해주세요.</span>
+                <span th:case="'login'">
+                    <span th:if="${param.message}" th:text="${param.message[0]}"></span>
+                    <span th:unless="${param.message}">로그인 중 오류가 발생했습니다. 다시 시도해주세요.</span>
+                </span>
                 <span th:case="*">로그인에 실패했습니다. 다시 시도해주세요.</span>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- parse backend login failures for backend-supplied error messages and propagate them back to the login redirect
- render backend error messages on the login page when provided, falling back to the existing generic copy otherwise
- cover the new behavior with a controller test that verifies the encoded redirect message

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68de464530e4832ca037096f9e8c639b